### PR TITLE
Add matching point option by zotero key already in database

### DIFF
--- a/src/Api/Adapter/ZoteroImportItemAdapter.php
+++ b/src/Api/Adapter/ZoteroImportItemAdapter.php
@@ -49,5 +49,11 @@ class ZoteroImportItemAdapter extends AbstractEntityAdapter
                 $this->createNamedParameter($qb, $query['import_id']))
             );
         }
+        if (isset($query['zoteroKey'])) {
+            $qb->andWhere($qb->expr()->eq(
+                'omeka_root.zoteroKey',
+                $this->createNamedParameter($qb, $query['zoteroKey']))
+            );
+        }
     }
 }

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -48,6 +48,7 @@ class IndexController extends AbstractActionController
                     'collectionKey' => $data['collectionKey'],
                     'apiKey' => $data['apiKey'],
                     'importFiles' => $data['importFiles'],
+                    'matchingPoint' => $data['matchingPoint'],
                     'version' => 0,
                     'timestamp' => $timestamp,
                 ];

--- a/src/Form/ImportForm.php
+++ b/src/Form/ImportForm.php
@@ -105,6 +105,18 @@ class ImportForm extends Form
             ],
         ]);
 
+        $this->add([
+            'name' => 'matchingPoint',
+            'type' => Element\Checkbox::class,
+            'options' => [
+                'label' => 'Matching point', // @translate
+                'info' => 'If this box is checked, a check will be performed on zotero key to avoid duplicates.', // @translate
+            ],
+            'attributes' => [
+                'id' => 'matching-point',
+            ],
+        ]);
+
         $inputFilter = $this->getInputFilter();
 
         $inputFilter->add([


### PR DESCRIPTION
If the option is checked on import configuration form you can now find the item already imported (by zotero key).
The content is then completely updated with zotero data, the item id still remains the same.